### PR TITLE
fix: IINA 1.4.4 plugin compatibility

### DIFF
--- a/IINA+/AppDelegate.swift
+++ b/IINA+/AppDelegate.swift
@@ -13,7 +13,7 @@ import Sparkle
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
 
-	let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+	@MainActor lazy var updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 	
     lazy var logUrl: URL? = {
         do {

--- a/IINA+/Utils/YouGetJSON.swift
+++ b/IINA+/Utils/YouGetJSON.swift
@@ -195,7 +195,7 @@ struct YouGetJSON: Unmarshaling, Codable {
         let port = Preferences.shared.dmPort
 		var args = [
 			"new_window=1",
-			"url=http://127.0.0.1:\(port)/video.mp4?",
+			"url=http://127.0.0.1:\(port)/video.mp4?\(argsStr)",
 			"mpv_\(MPVOption.ProgramBehavior.scriptOpts)=iinaPlusArgs=\(argsStr)"
 		]
 		args = args.compactMap { kvs -> String? in
@@ -208,9 +208,8 @@ struct YouGetJSON: Unmarshaling, Codable {
 			let k = kv[0]
 			return "\(k)=\(v)"
 		}
-        
+		
         guard args.count == 3 else { return nil }
-        args[1] = args[1] + String(args[2].suffix(25))
         
 		return u + args.joined(separator: "&")
 	}


### PR DESCRIPTION
IINA 1.4.4 no longer delivers 'iina.file-started' events to plugins, and URL-scheme mpv_script-opts are not passed through to mpv.

This causes Bilibili videos to only play the 15-second empty.m4a placeholder with no video/audio (#255).

## Changes
- **YouGetJSON.swift**: Put full iinaPlusArgs hex in `video.mp4?` URL query (previously only last 25 chars as suffix check)
- **AppDelegate.swift**: Add `@MainActor` to fix Sparkle init on Swift 6 strict concurrency

## Related
Requires companion fix in iina-plugin-danmaku main.js: use `mpv.addHook('on_load')` to intercept file loading.

Fixes #255

---

Generated with assistance from glm